### PR TITLE
Allow sub-euro rounding tolerance in CAM-016 AUM consistency check

### DIFF
--- a/aifmd.xslt
+++ b/aifmd.xslt
@@ -298,7 +298,9 @@
 			<xsl:variable
 					name="result"
 					select="$amounteuro * $rateeuro" />
-			<xsl:if test="not($amountbase = $result)">
+			<!-- AUMAmountInEuro is a whole number of euros, so allow a rounding
+			     tolerance of up to one euro (i.e. the FX rate in base currency) -->
+			<xsl:if test="($result - $amountbase &gt;= $rateeuro) or ($amountbase - $result &gt;= $rateeuro)">
 				<xsl:call-template name="AIFMError">
 					<xsl:with-param
 							name="code"


### PR DESCRIPTION
CAM-016 required AUMAmountInBaseCurrency to equal AUMAmountInEuro × FXEURRate exactly, which is unreachable for non-EUR funds: AUMAmountInEuro is a whole number of euros (XSD fractionDigits=0) and FXEURRate has at most 4 decimals, so exact equality only holds when the base amount is an exact multiple of the rate — almost never. Replace it with a tolerance of strictly less than one euro, the tightest that admits every correctly rounded amount while still catching any discrepancy of one euro or more.